### PR TITLE
update empty plist format

### DIFF
--- a/RCTTextInputUtils.xcodeproj/xcuserdata/libinlu.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/RCTTextInputUtils.xcodeproj/xcuserdata/libinlu.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+</plist>


### PR DESCRIPTION
fix plist parsing error when running `react-native-schemes-manager all` command